### PR TITLE
IE7 broke at narrower widths.

### DIFF
--- a/css/default.css
+++ b/css/default.css
@@ -796,7 +796,7 @@ body {
     width:440px;
 }
 
-[role="main"] {
+article, [role="main"] {
     width:420px;
 }
 
@@ -844,7 +844,7 @@ body {
     width:300px;
 }
 
-[role="main"] {
+article, [role="main"] {
     width:280px;
 }
 


### PR DESCRIPTION
article, [role="main"] {width:420px;} and article, [role="main"] {width:280px;} (for IE7)
