### PR TITLE
Proportional scaling for wide images; embed iframes

### DIFF
--- a/sass/_embedded-content.scss
+++ b/sass/_embedded-content.scss
@@ -26,8 +26,11 @@ svg:not(:root) {
 }
 
 article {
-	img, embed, object, video {
+	img, embed, object, video, iframe {
 		max-width: 100%;
+	}
+	img {
+		height: auto;
 	}
 }
 


### PR DESCRIPTION
Hi Phil,

here's a tiny fix for embedded content:
1. adds IFRAME to the list of embeddable elements
2. forces images to scale proportionally on narrow screens even when the markup contains an explicit `height` attribute: `<img src="./images/1.jpg" alt="" width="800" height="600" />` I think this is reasonable as both TinyMCE and various Textpattern tags default to include the image dimensions in the elements `width/height` attribute.
