### PR TITLE
Check for external links before displaying them

### DIFF
--- a/pages/archive.txp
+++ b/pages/archive.txp
@@ -165,12 +165,17 @@
                     <txp:feed_link class="feed-atom" flavor="atom" label="Atom" />
                 </p>
 
-                <h4>
-                    <txp:text item="external_links" />
-                </h4>
+                <txp:variable name="external_links" value='<txp:linklist limit="1" />' />
 
-                <!-- links by default to form: 'plainlinks.link.txp' unless you specify a different form -->
-                <txp:linklist wraptag="ul" break="li" limit="10" />
+                <txp:if_variable name="external_links" value="">
+                <txp:else />
+                    <h4>
+                        <txp:text item="external_links" />
+                    </h4>
+
+                    <!-- links by default to form: 'plainlinks.link.txp' unless you specify a different form -->
+                    <txp:linklist wraptag="ul" break="li" limit="10" />
+                </txp:if_variable>
 
             </div> <!-- /complementary -->
 

--- a/pages/default.txp
+++ b/pages/default.txp
@@ -177,12 +177,17 @@
                     <txp:feed_link class="feed-atom" flavor="atom" label="Atom" />
                 </p>
 
-                <h4>
-                    <txp:text item="external_links" />
-                </h4>
+                <txp:variable name="external_links" value='<txp:linklist wraptag="ul" break="li" limit="10" />' />
 
-                <!-- links by default to form: 'plainlinks.link.txp' unless you specify a different form -->
-                <txp:linklist wraptag="ul" break="li" limit="10" />
+                <txp:if_variable name="external_links" value="">
+                <txp:else />
+                    <h4>
+                        <txp:text item="external_links" />
+                    </h4>
+
+                    <!-- links by default to form: 'plainlinks.link.txp' unless you specify a different form -->
+                    <txp:linklist wraptag="ul" break="li" limit="10" />
+                </txp:if_variable>
 
             </div> <!-- /complementary -->
 

--- a/pages/error_default.txp
+++ b/pages/error_default.txp
@@ -78,12 +78,17 @@
                     <txp:feed_link class="feed-atom" flavor="atom" label="Atom" />
                 </p>
 
-                <h4>
-                    <txp:text item="external_links" />
-                </h4>
+                <txp:variable name="external_links" value='<txp:linklist limit="1" />' />
 
-                <!-- links by default to form: 'plainlinks.link.txp' unless you specify a different form -->
-                <txp:linklist wraptag="ul" break="li" limit="10" />
+                <txp:if_variable name="external_links" value="">
+                <txp:else />
+                    <h4>
+                        <txp:text item="external_links" />
+                    </h4>
+
+                    <!-- links by default to form: 'plainlinks.link.txp' unless you specify a different form -->
+                    <txp:linklist wraptag="ul" break="li" limit="10" />
+                </txp:if_variable>
 
             </div> <!-- /complementary -->
 


### PR DESCRIPTION
If a user deletes the Textpattern-related links and doesn't populate with any others, the sidebar `h4` still appears regardless, which looks odd.

This PR wraps the `h4` and subsequent list in a variable, checking for the existence of 1 or more links.
