### PR TITLE
Tweak categories handling, fix space-comma-space

### DIFF
--- a/forms/default.article.txp
+++ b/forms/default.article.txp
@@ -61,11 +61,9 @@
                 <txp:text item="categories" />
             </strong>
             <span itemprop="keywords">
-                <txp:category1 title="1" link="1" />
-                <txp:if_article_category number="1">
-                    <txp:if_article_category number="2">, </txp:if_article_category>
+                <txp:if_article_category number="1"><txp:category1 title="1" link="1" /></txp:if_article_category><txp:if_article_category number="2"><txp:if_article_category number="1">, </txp:if_article_category>
+                    <txp:category2 title="1" link="1" />
                 </txp:if_article_category>
-                <txp:category2 title="1" link="1" />
             </span>
         </txp:if_article_category>
 


### PR DESCRIPTION
This fixes an awkward space-comma-space in article category display due to line breaks.

It also makes fewer assumptions about setting of `category1` and `category2` - for example, now just `category2` can be set and it won’t display the comma-space if `category1` isn’t set.

_Was originally https://github.com/textpattern/textpattern-default-theme/pull/52 but I didn’t commit properly. The horror._
